### PR TITLE
Only set test port if its non-zero

### DIFF
--- a/deployment/src/main/java/io/github/microcks/quarkus/deployment/DevServicesMicrocksProcessor.java
+++ b/deployment/src/main/java/io/github/microcks/quarkus/deployment/DevServicesMicrocksProcessor.java
@@ -224,7 +224,10 @@ public class DevServicesMicrocksProcessor {
          Config globalConfig = ConfigProviderResolver.instance().getConfig();
          int testPort = globalConfig.getValue("quarkus.http.test-port", OptionalInt.class)
                .orElse(8081);
-         Testcontainers.exposeHostPorts(testPort);
+
+         if (testPort >= 0) {
+             Testcontainers.exposeHostPorts(testPort);
+         }
 
          // Add envs and timeout if provided.
          microcksContainer.withEnv(devServicesConfig.containerEnv());

--- a/deployment/src/main/java/io/github/microcks/quarkus/deployment/DevServicesMicrocksProcessor.java
+++ b/deployment/src/main/java/io/github/microcks/quarkus/deployment/DevServicesMicrocksProcessor.java
@@ -225,7 +225,7 @@ public class DevServicesMicrocksProcessor {
          int testPort = globalConfig.getValue("quarkus.http.test-port", OptionalInt.class)
                .orElse(8081);
 
-         if (testPort >= 0) {
+         if (testPort > 0) {
              Testcontainers.exposeHostPorts(testPort);
          }
 


### PR DESCRIPTION
Only set test port if non-zero

Sometimes an app may be configured to use a random port by setting `quarkus.http.test-port=0`. If the port is `0`, then the call to `Testcontainers.exposeHostPorts` fails.