### PR TITLE
Adding separate properties for http host and port

### DIFF
--- a/deployment/src/main/java/io/github/microcks/quarkus/deployment/DevServicesMicrocksProcessor.java
+++ b/deployment/src/main/java/io/github/microcks/quarkus/deployment/DevServicesMicrocksProcessor.java
@@ -271,7 +271,7 @@ public class DevServicesMicrocksProcessor {
                      CONFIG_PREFIX + "default" + HTTP_HOST_SUFFIX, visiblehost,
                      CONFIG_PREFIX + "default" + HTTP_PORT_SUFFIX, microcksContainer.getMappedPort(MicrocksContainer.MICROCKS_HTTP_PORT).toString(),
                      CONFIG_PREFIX + "default" + GRPC_SUFFIX, microcksGrpcHost,
-                     CONFIG_PREFIX + "default" + GRPC_HOST_SUFFIX, visibleHost,
+                     CONFIG_PREFIX + "default" + GRPC_HOST_SUFFIX, visiblehost,
                      CONFIG_PREFIX + "default" + GRPC_PORT_SUFFIX, microcksContainer.getMappedPort(MicrocksContainer.MICROCKS_GRPC_PORT).toString()));
          devServiceMicrocksContainerMap.put(devService, microcksContainer);
 

--- a/deployment/src/main/java/io/github/microcks/quarkus/deployment/DevServicesMicrocksProcessor.java
+++ b/deployment/src/main/java/io/github/microcks/quarkus/deployment/DevServicesMicrocksProcessor.java
@@ -81,6 +81,8 @@ public class DevServicesMicrocksProcessor {
 
    private static final String CONFIG_PREFIX = "quarkus.microcks.";
    private static final String HTTP_SUFFIX = ".http";
+   private static final String HTTP_HOST_SUFFIX = ".http.host";
+   private static final String HTTP_PORT_SUFFIX = ".http.port";
    private static final String GRPC_SUFFIX = ".grpc";
    private static final String GRPC_HOST_SUFFIX = ".grpc.host";
    private static final String GRPC_PORT_SUFFIX = ".grpc.port";
@@ -266,6 +268,8 @@ public class DevServicesMicrocksProcessor {
 
          RunningDevService devService = new RunningDevService(DEV_SERVICE_NAME, microcksContainer.getContainerId(), microcksContainer::close,
                Map.of(CONFIG_PREFIX + "default" + HTTP_SUFFIX, microcksHttpHost,
+                     CONFIG_PREFIX + "default" + HTTP_HOST_SUFFIX, visibleHost,
+                     CONFIG_PREFIX + "default" + HTTP_PORT_SUFFIX, microcksContainer.getMappedPort(MicrocksContainer.MICROCKS_HTTP_PORT).toString(),
                      CONFIG_PREFIX + "default" + GRPC_SUFFIX, microcksGrpcHost,
                      CONFIG_PREFIX + "default" + GRPC_HOST_SUFFIX, visiblehost,
                      CONFIG_PREFIX + "default" + GRPC_PORT_SUFFIX, microcksContainer.getMappedPort(MicrocksContainer.MICROCKS_GRPC_PORT).toString()));

--- a/deployment/src/main/java/io/github/microcks/quarkus/deployment/DevServicesMicrocksProcessor.java
+++ b/deployment/src/main/java/io/github/microcks/quarkus/deployment/DevServicesMicrocksProcessor.java
@@ -268,10 +268,10 @@ public class DevServicesMicrocksProcessor {
 
          RunningDevService devService = new RunningDevService(DEV_SERVICE_NAME, microcksContainer.getContainerId(), microcksContainer::close,
                Map.of(CONFIG_PREFIX + "default" + HTTP_SUFFIX, microcksHttpHost,
-                     CONFIG_PREFIX + "default" + HTTP_HOST_SUFFIX, visibleHost,
+                     CONFIG_PREFIX + "default" + HTTP_HOST_SUFFIX, visiblehost,
                      CONFIG_PREFIX + "default" + HTTP_PORT_SUFFIX, microcksContainer.getMappedPort(MicrocksContainer.MICROCKS_HTTP_PORT).toString(),
                      CONFIG_PREFIX + "default" + GRPC_SUFFIX, microcksGrpcHost,
-                     CONFIG_PREFIX + "default" + GRPC_HOST_SUFFIX, visiblehost,
+                     CONFIG_PREFIX + "default" + GRPC_HOST_SUFFIX, visibleHost,
                      CONFIG_PREFIX + "default" + GRPC_PORT_SUFFIX, microcksContainer.getMappedPort(MicrocksContainer.MICROCKS_GRPC_PORT).toString()));
          devServiceMicrocksContainerMap.put(devService, microcksContainer);
 


### PR DESCRIPTION
As I was incorporating this into a quarkus application that uses Stork I noticed I could not simply re-use the full http URL because it had the scheme applied (`http://host:port`).

For static service discovery stork requires the host:port combo without the scheme, like this:

```properties
quarkus.stork.hero-service.service-discovery.address-list=localhost:8083
```

So I need to be able to do this:

```properties
quarkus.stork.hero-service.service-discovery.address-list=${quarkus.microcks.default.http.host}:${quarkus.microcks.default.http.port}
```