### PR TITLE
fix: open port for dev mode

### DIFF
--- a/deployment/src/main/java/io/github/microcks/quarkus/deployment/DevServicesMicrocksProcessor.java
+++ b/deployment/src/main/java/io/github/microcks/quarkus/deployment/DevServicesMicrocksProcessor.java
@@ -367,10 +367,11 @@ public class DevServicesMicrocksProcessor {
          // Configure access to host - getting test-port from config or defaulting to 8081.
          microcksContainer.withAccessToHost(devServicesConfig.hostAccess());
          Config globalConfig = ConfigProviderResolver.instance().getConfig();
+         int devPort = globalConfig.getValue("quarkus.http.port", OptionalInt.class).orElse(8080);
          int testPort = globalConfig.getValue("quarkus.http.test-port", OptionalInt.class).orElse(8081);
 
          if (testPort > 0 && devServicesConfig.hostAccess()) {
-            Testcontainers.exposeHostPorts(testPort);
+            Testcontainers.exposeHostPorts(devPort, testPort);
          }
 
          // Add envs and timeout if provided.


### PR DESCRIPTION
### Description

When the extension starts Microcks, it exposes the port defined with `quarkus.http.test-port`, defaulted to `8081`, in Testcontainers.
While this works fine when running Microcks for `@QuarkusTest`, it is an issue when running in dev mode: By default, Quarkus starts the application using `quarkus.http.port`, defaulted to `8080`, so Microcks running in Testcontainer cannot reach the application as only the port `8081` is exposed.

### Related issue(s)

Fixes #204